### PR TITLE
Fix regex generation for automata without self-loops

### DIFF
--- a/index.html
+++ b/index.html
@@ -897,7 +897,7 @@
 
       for (const k of statesOrder) {
         const Rkk = G[k][k] || null;
-        const starK = Rkk ? star(Rkk) : null;
+        const starK = star(Rkk);
         for (let i = 0; i < N; i++) {
           if (i === k) continue;
           const Rik = G[i][k] || null;


### PR DESCRIPTION
## Summary
- correct state elimination to treat missing self-loops as ε when building regex

## Testing
- `node /tmp/test.js`


------
https://chatgpt.com/codex/tasks/task_e_689fb13286148333a3fb5f002deafe63