### PR TITLE
Add step-by-step run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # automatonSim
 just a automaton simulator to practice Foundations of Theoretical Computer Science
+
+## Features
+
+- Build and edit deterministic finite automata in the browser.
+- Simulate words normally via **Rodar** or step-by-step using **Modo Run** with a manual *Passo* button.

--- a/index.html
+++ b/index.html
@@ -47,6 +47,8 @@
         <div class="row">
           <input type="text" id="wordInput" placeholder="Ex: ABAAB" />
           <button id="runBtn" class="btn-accent">Rodar</button>
+          <button id="runStartBtn" class="btn-soft">Modo Run</button>
+          <button id="runStepBtn" class="btn-soft" disabled>Passo</button>
         </div>
         <div id="runResult" class="mini"></div>
         <div id="runSteps" class="scroll mini"></div>


### PR DESCRIPTION
## Summary
- add Run mode to simulate input character by character
- introduce stepper controls to advance automaton transitions
- document new interactive Run feature in README

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a08228799483338d9329cb07b9fb18