### PR TITLE
Add AFN module with tab navigation

### DIFF
--- a/afn.html
+++ b/afn.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>Simulador Interativo de AFD</title>
+  <title>Simulador Interativo de AFN</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="style.css">
 </head>
@@ -11,8 +11,8 @@
 <body>
 
   <nav class="tabs">
-    <a href="index.html" class="active">AFD</a>
-    <a href="afn.html">AFN</a>
+    <a href="index.html">AFD</a>
+    <a href="afn.html" class="active">AFN</a>
   </nav>
 
   <div class="left">
@@ -113,6 +113,7 @@
     </div>
   </div>
 
+    <script>window.LS_KEY='afn_sim_state_v1';</script>
     <script src="script.js"></script>
     <script src="run.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -10,7 +10,7 @@
       initialId: undefined,
     };
 
-    const LS_KEY = 'afd_sim_state_v3';
+    const LS_KEY = window.LS_KEY || 'afd_sim_state_v3';
 
     const svg = document.getElementById('svg');
     const gStates = document.getElementById('states');

--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@
       height: 100vh;
       display: flex;
       gap: 16px;
-      padding: 16px;
+      padding: 56px 16px 16px;
     }
 
     .left,
@@ -312,4 +312,28 @@
       border-radius: 999px;
       border: 1px solid rgba(255, 255, 255, .2);
       background: rgba(255, 255, 255, .05)
+    }
+
+    .tabs {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      gap: 8px;
+      background: var(--panel);
+      padding: 8px 16px;
+      z-index: 100;
+    }
+
+    .tabs a {
+      color: var(--ink);
+      text-decoration: none;
+      padding: 6px 12px;
+      border-radius: 8px;
+      border: 1px solid rgba(255, 255, 255, .12);
+    }
+
+    .tabs a.active {
+      background: var(--soft);
     }


### PR DESCRIPTION
## Summary
- Add navigation tabs and AFD-focused index page
- Create dedicated AFN page storing its own automaton
- Allow custom localStorage key via window.LS_KEY and add styles for new tab bar

## Testing
- `node --check script.js`
- `node --check run.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0912374608333ad4543fcee8b84b5