### PR TITLE
fix: keep element during selection to allow renaming

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,8 +38,16 @@
       return Array.from(A.alphabet).join(', ');
     }
     function markSelected(id) {
+      const prev = A.selectedStateId;
       A.selectedStateId = id;
-      renderStates();
+
+      if (prev && prev !== id) {
+        const prevCircle = gStates.querySelector(`g.state[data-id="${prev}"] circle`);
+        if (prevCircle) prevCircle.style.stroke = '';
+      }
+
+      const circle = gStates.querySelector(`g.state[data-id="${id}"] circle`);
+      if (circle) circle.style.stroke = 'var(--accent)';
     }
     function ensureUniqueSymbols(str) {
       return Array.from(new Set(str.split(',').map(s => s.trim()).filter(Boolean)));


### PR DESCRIPTION
## Summary
- avoid full re-render when selecting a state by updating highlight directly
- allow double-click state renaming to work correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b1758e888333af2ee189d1e40578