### PR TITLE
Add rename icon and recolor connect handle

### DIFF
--- a/script.js
+++ b/script.js
@@ -266,6 +266,22 @@
             A.connectFrom = s.id;
           });
           g.appendChild(handle);
+
+          const renameHandle = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+          renameHandle.setAttribute('d', 'M2.69509 14.7623L1.4333 17.9168C1.27004 18.3249 1.67508 18.73 2.08324 18.5667L5.2377 17.3049C5.74067 17.1037 6.19753 16.8025 6.58057 16.4194L17.4998 5.50072C18.3282 4.67229 18.3282 3.32914 17.4998 2.50072C16.6713 1.67229 15.3282 1.67229 14.4998 2.50071L3.58057 13.4194C3.19752 13.8025 2.89627 14.2593 2.69509 14.7623Z');
+          renameHandle.setAttribute('class', 'rename-handle');
+          renameHandle.setAttribute('transform', `translate(${s.x + r + 6},${s.y - r - 44}) scale(0.66)`);
+          renameHandle.addEventListener('mousedown', ev => {
+            ev.stopPropagation();
+            ev.preventDefault();
+            const newName = prompt('Novo nome do estado:', s.name);
+            if (newName && newName.trim() !== '') {
+              s.name = newName.trim();
+              saveLS();
+              renderAll();
+            }
+          });
+          g.appendChild(renameHandle);
         }
 
         gStates.appendChild(g);

--- a/style.css
+++ b/style.css
@@ -243,6 +243,13 @@
     }
 
     .connect-handle {
+      fill: var(--accent2);
+      stroke: var(--bg);
+      stroke-width: 2;
+      cursor: pointer
+    }
+
+    .rename-handle {
       fill: var(--accent);
       stroke: var(--bg);
       stroke-width: 2;


### PR DESCRIPTION
## Summary
- add a rename icon on selected states for easy renaming
- recolor the connect (link) icon for better visibility

## Testing
- `node -c script.js`
- `node -c run.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1dd7cf574833399d5e6716f48b910