### PR TITLE
Add lambda-NFA support and conversions to DFA

### DIFF
--- a/afn.html
+++ b/afn.html
@@ -79,6 +79,14 @@
       <div class="mini muted">Exporta um JSON com Σ, estados, transições, inicial e <code>nextId</code>. Importar
         substituirá o AF atual.</div>
     </div>
+
+    <div class="card">
+      <h2>Conversões</h2>
+      <div class="toolbar">
+        <button id="lambdaToNfaBtn" class="btn-soft">AFNλ → AFN</button>
+        <button id="nfaToDfaBtn" class="btn-soft">AFN → AFD</button>
+      </div>
+    </div>
   </div>
 
   <div class="right card" style="flex:1.2">


### PR DESCRIPTION
## Summary
- Support λ-transitions and provide conversion utilities from λ-NFA to NFA and from NFA to DFA
- Add UI buttons for performing automaton conversions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b22dc15dd8833394987743a5876934