### PR TITLE
feat: add connect mode indicator

### DIFF
--- a/style.css
+++ b/style.css
@@ -344,3 +344,38 @@
     .tabs a.active {
       background: var(--soft);
     }
+
+    @keyframes connect-pulse {
+      0%, 100% { stroke-width: 3px; }
+      50% { stroke-width: 6px; }
+    }
+
+    .connect-mode svg {
+      cursor: crosshair;
+    }
+
+    .connect-mode .state,
+    .connect-mode .state:active {
+      cursor: crosshair;
+    }
+
+    .connect-mode .state.connect-from .st-circle {
+      stroke: var(--accent);
+      animation: connect-pulse 1s infinite;
+    }
+
+    .connect-mode::after {
+      content: 'Conectando estados – clique na origem e no destino';
+      position: fixed;
+      top: 8px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--accent);
+      color: var(--bg);
+      padding: 4px 12px;
+      border-radius: 8px;
+      font-weight: 700;
+      z-index: 200;
+      pointer-events: none;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, .3);
+    }


### PR DESCRIPTION
## Summary
- highlight origin state and toggle crosshair during connect mode
- show instructional banner when connecting states
- ensure connect mode UI resets after completing or cancelling connections

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b23e8b99048333aa7e082b86003c32