### PR TITLE
feat: visualize AFN conversions step by step

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ just a automaton simulator to practice Foundations of Theoretical Computer Scien
 
 - Build and edit deterministic and nondeterministic finite automata (with λ-transitions) in the browser.
 - Simulate words normally via **Rodar** or step-by-step using **Modo Run** with a manual *Passo* button.
+
+## Algorithm visualization
+
+In the AFN interface (`afn.html`) the conversion buttons now display each step of the algorithms:
+
+1. **AFNλ → AFN** – shows how λ-transitions are eliminated.
+2. **AFN → AFD** – illustrates the subset construction.
+
+The steps appear in a panel below the conversion buttons and highlight the states involved during the process.

--- a/afn.html
+++ b/afn.html
@@ -86,6 +86,7 @@
         <button id="lambdaToNfaBtn" class="btn-soft">AFNλ → AFN</button>
         <button id="nfaToDfaBtn" class="btn-soft">AFN → AFD</button>
       </div>
+      <div id="algoSteps" class="mini scroll"></div>
     </div>
   </div>
 
@@ -124,6 +125,7 @@
 
     <script>window.LS_KEY='afn_sim_state_v1';</script>
     <script type="module" src="js/run.js"></script>
+    <script type="module" src="js/algoview.js"></script>
 </body>
 
 </html>

--- a/js/algoview.js
+++ b/js/algoview.js
@@ -1,0 +1,54 @@
+import { A, renderStates, runHighlight } from './core.js';
+
+const elSteps = document.getElementById('algoSteps');
+const titles = {
+  removeLambda: 'AFNλ → AFN',
+  nfaToDfa: 'AFN → AFD',
+};
+
+function nameOf(id) {
+  return A.states.get(id)?.name || id;
+}
+
+document.addEventListener('algoStep', ev => {
+  if (!elSteps) return;
+  const { algo, step, ...data } = ev.detail;
+  if (step === 'start') {
+    elSteps.innerHTML = `<strong>${titles[algo] || algo}</strong>`;
+    runHighlight.clear();
+    renderStates();
+    return;
+  }
+  const div = document.createElement('div');
+  if (algo === 'removeLambda') {
+    if (step === 'closure') {
+      div.textContent = `ε-fecho(${nameOf(data.state)}) = {${data.closure.map(nameOf).join(', ')}}`;
+    } else if (step === 'final') {
+      div.textContent = `${nameOf(data.state)} ${data.isFinal ? 'é' : 'não é'} final`;
+    } else if (step === 'transition') {
+      div.textContent = `(${nameOf(data.from)}, ${data.sym}) → {${data.to.map(nameOf).join(', ')}}`;
+      runHighlight.clear();
+      runHighlight.set(data.from, 'running');
+      data.to.forEach(id => runHighlight.set(id, 'running'));
+      renderStates();
+    } else {
+      div.textContent = `${step}`;
+    }
+  } else if (algo === 'nfaToDfa') {
+    if (step === 'newState') {
+      div.textContent = `novo estado ${nameOf(data.id)} = {${data.subset.map(nameOf).join(', ')}}`;
+    } else if (step === 'transition') {
+      div.textContent = `(${nameOf(data.from)}, ${data.sym}) → ${nameOf(data.to)}`;
+      runHighlight.clear();
+      runHighlight.set(data.from, 'running');
+      runHighlight.set(data.to, 'running');
+      renderStates();
+    } else {
+      div.textContent = `${step}`;
+    }
+  } else {
+    div.textContent = `${algo}:${step}`;
+  }
+  elSteps.appendChild(div);
+});
+


### PR DESCRIPTION
## Summary
- emit step events from lambda removal and NFA→DFA conversions
- add UI panel and listener module to display algorithm steps
- document algorithm visualization in README

## Testing
- `node --check js/core.js js/run.js js/algoview.js`


------
https://chatgpt.com/codex/tasks/task_e_68b443f41c588333b5061fc88e3b1d21