### PR TITLE
Allow running without module scripts

### DIFF
--- a/afn.html
+++ b/afn.html
@@ -124,8 +124,9 @@
   </div>
 
     <script>window.LS_KEY='afn_sim_state_v1';</script>
-    <script type="module" src="js/run.js"></script>
-    <script type="module" src="js/algoview.js"></script>
-</body>
+    <script src="js/core.js"></script>
+    <script src="js/run.js"></script>
+    <script src="js/algoview.js"></script>
+  </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -114,7 +114,8 @@
     </div>
   </div>
 
-    <script type="module" src="js/run.js"></script>
-</body>
+    <script src="js/core.js"></script>
+    <script src="js/run.js"></script>
+  </body>
 
 </html>

--- a/js/algoview.js
+++ b/js/algoview.js
@@ -1,5 +1,3 @@
-import { A, renderStates, runHighlight } from './core.js';
-
 const elSteps = document.getElementById('algoSteps');
 const titles = {
   removeLambda: 'AFNλ → AFN',

--- a/js/core.js
+++ b/js/core.js
@@ -978,7 +978,4 @@
       convertNfaToDfa();
     };
 
-    renderAll();
-
-
-export { A, keyTS, alphaStr, renderStates, runHighlight, svg };
+renderAll();

--- a/js/run.js
+++ b/js/run.js
@@ -1,5 +1,3 @@
-import { A, keyTS, alphaStr, renderStates, runHighlight, svg } from "./core.js";
-
 const elRunResult = document.getElementById('runResult');
 const elRunSteps = document.getElementById('runSteps');
 const runBtn = document.getElementById('runBtn');


### PR DESCRIPTION
## Summary
- load JavaScript files without ES module imports
- remove exports in core.js and update HTML to include scripts directly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b452e5775c83339567fb2bbb1fddea