### PR TITLE
Add regular grammar to automaton conversion page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ just a automaton simulator to practice Foundations of Theoretical Computer Scien
 ## Features
 
 - Build and edit deterministic and nondeterministic finite automata (with λ-transitions) in the browser.
+- Generate finite automata from regular grammars on the new `gr.html` page.
 - Simulate words normally via **Rodar** or step-by-step using **Modo Run** with a manual *Passo* button.
 
 ## Algorithm visualization

--- a/afn.html
+++ b/afn.html
@@ -13,6 +13,7 @@
   <nav class="tabs">
     <a href="index.html">AFD</a>
     <a href="afn.html" class="active">AFN</a>
+    <a href="gr.html">GR</a>
   </nav>
 
   <div class="left">

--- a/gr.html
+++ b/gr.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+
+<head>
+  <meta charset="utf-8" />
+  <title>Gramática → Autômato</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+  <nav class="tabs">
+    <a href="index.html">AFD</a>
+    <a href="afn.html">AFN</a>
+    <a href="gr.html" class="active">GR</a>
+  </nav>
+
+  <div class="left">
+    <div class="card">
+      <h2>Gramática Regular</h2>
+      <textarea id="grammarInput" rows="6" placeholder="S->aA|b&#10;A->aS|λ"></textarea>
+      <div class="row">
+        <button id="buildFromGrammarBtn" class="btn-accent">Gerar AF</button>
+      </div>
+      <div class="mini muted">Use λ para a produção vazia.</div>
+    </div>
+
+    <div class="card">
+      <h2>Alfabeto</h2>
+      <div class="row">
+        <input type="text" id="alphabetInput" placeholder="Símbolos separados por vírgula. Ex: A,B" />
+        <button class="btn-accent" id="setAlphabetBtn">Definir</button>
+        <span class="muted mini">Use apenas símbolos unitários (sem strings). Ex.: <span class="kbd">A</span>, <span
+            class="kbd">B</span>, <span class="kbd">0</span>, <span class="kbd">1</span>.</span>
+      </div>
+      <div id="alphabetView" class="pill muted">Σ = { }</div>
+    </div>
+
+    <div class="card">
+      <h2>Estados</h2>
+      <div class="toolbar">
+        <button id="addStateBtn">+ Estado</button>
+        <button id="toggleInitialBtn" class="btn-soft">Alternar Inicial</button>
+        <button id="toggleFinalBtn" class="btn-soft">Alternar Final</button>
+        <button id="deleteSelectedBtn" class="btn-danger">Excluir Selecionado</button>
+        <button id="resetBtn" class="btn-danger">Limpar AF</button>
+      </div>
+      <div class="legend">
+        <span class="dot dot-initial"></span><span class="mini">Inicial</span>
+        <span class="dot dot-final"></span><span class="mini">Final</span>
+        <span class="dot dot-halt"></span><span class="mini">HALT (transição ausente)</span>
+      </div>
+      <div class="hr"></div>
+      <div class="row mini muted">Dica: clique em um estado para selecioná-lo. Use <span class="kbd">C</span> ou o ícone
+        de ligação para conectar: clique na origem e depois no destino para escolher o símbolo.</div>
+    </div>
+
+    <div class="card grid cols-2">
+      <div>
+        <h2>Simular Palavra</h2>
+        <div class="row">
+          <input type="text" id="wordInput" placeholder="Ex: ABAAB" />
+          <button id="runBtn" class="btn-accent">Rodar</button>
+          <button id="runStartBtn" class="btn-soft">Modo Run</button>
+          <button id="runStepBtn" class="btn-soft" disabled>Passo</button>
+        </div>
+        <div id="runResult" class="mini"></div>
+        <div id="runSteps" class="scroll mini"></div>
+      </div>
+      <div>
+        <h2>Expressão Regular (AFD → ER)</h2>
+        <div class="row">
+          <label><input type="checkbox" id="allowEpsilon" /> Permitir λ na saída</label>
+          <button id="buildRegexBtn">Gerar ER</button>
+        </div>
+        <div id="regexMsg" class="mini muted"></div>
+        <div id="regexOut" class="pill" style="margin-top:6px; font-weight:700; font-size:15px;"></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Exportar / Importar</h2>
+      <div class="toolbar">
+        <button id="exportBtn" class="btn-soft">Exportar AF</button>
+        <button id="importBtn" class="btn-soft">Importar AF</button>
+        <input type="file" id="importFile" accept="application/json" style="display:none" />
+      </div>
+      <div class="mini muted">Exporta um JSON com Σ, estados, transições, inicial e <code>nextId</code>. Importar
+        substituirá o AF atual.</div>
+    </div>
+
+    <div class="card">
+      <h2>Conversões</h2>
+      <div class="toolbar">
+        <button id="lambdaToNfaBtn" class="btn-soft">AFNλ → AFN</button>
+        <button id="nfaToDfaBtn" class="btn-soft">AFN → AFD</button>
+      </div>
+      <div id="algoSteps" class="mini scroll"></div>
+    </div>
+  </div>
+
+  <div class="right card" style="flex:1.2">
+    <h2>Canvas</h2>
+    <div id="canvasWrapper">
+      <svg id="svg">
+        <defs>
+          <marker id="arrow" markerWidth="18" markerHeight="12" refX="10" refY="6" orient="auto"
+            markerUnits="strokeWidth">
+            <path d="M0,0 L10,6 L0,12 z" fill="#cbd5e1"></path>
+          </marker>
+        </defs>
+        <g id="edges"></g>
+        <g id="labels"></g>
+        <g id="initialPointers"></g>
+        <g id="states"></g>
+      </svg>
+    </div>
+    <div class="hr"></div>
+    <div class="mini muted">Transições</div>
+    <div id="transitionsList" class="scroll mini"></div>
+  </div>
+
+
+  <div class="card">
+    <h2>Operações entre AFDs</h2>
+    <div class="toolbar">
+      <button id="unionBtn" class="btn-soft">União</button>
+      <button id="intersectionBtn" class="btn-soft">Interseção</button>
+      <button id="equivalenceBtn" class="btn-soft">Equivalência</button>
+      <input type="file" id="importFile1" accept="application/json" style="display:none" />
+      <input type="file" id="importFile2" accept="application/json" style="display:none" />
+    </div>
+  </div>
+
+    <script>window.LS_KEY='afn_gr_sim_state_v1';</script>
+    <script src="js/core.js"></script>
+    <script src="js/grammar.js"></script>
+    <script src="js/run.js"></script>
+    <script src="js/algoview.js"></script>
+  </body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <nav class="tabs">
     <a href="index.html" class="active">AFD</a>
     <a href="afn.html">AFN</a>
+    <a href="gr.html">GR</a>
   </nav>
 
   <div class="left">

--- a/js/grammar.js
+++ b/js/grammar.js
@@ -1,0 +1,68 @@
+// Constrói um AF a partir de uma gramática regular
+function buildFromGrammar() {
+  const raw = document.getElementById('grammarInput').value;
+  const lines = raw.split(/\n+/).map(l => l.trim()).filter(Boolean);
+  if (!lines.length) return;
+  resetAll();
+  const ntMap = new Map();
+  const alphabet = new Set();
+  const transitions = [];
+  let startNt = null;
+
+  function ensureState(nt) {
+    if (!ntMap.has(nt)) {
+      const sid = id();
+      const s = { id: sid, name: nt, x: 120 + Math.random()*320, y: 120 + Math.random()*220, isInitial: false, isFinal: false };
+      A.states.set(sid, s);
+      ntMap.set(nt, sid);
+    }
+    return ntMap.get(nt);
+  }
+
+  for (const line of lines) {
+    const [lhs, rhs] = line.split('->').map(s => s.trim());
+    if (!lhs || !rhs) continue;
+    if (!startNt) startNt = lhs;
+    const fromId = ensureState(lhs);
+    const prods = rhs.split('|').map(p => p.trim()).filter(Boolean);
+    for (const prod of prods) {
+      if (prod === 'λ' || prod === 'epsilon' || prod === 'ε') {
+        A.states.get(fromId).isFinal = true;
+        continue;
+      }
+      const sym = prod.charAt(0);
+      alphabet.add(sym);
+      const rest = prod.slice(1);
+      if (!rest) {
+        transitions.push([fromId, sym, 'FINAL']);
+      } else {
+        const toId = ensureState(rest);
+        transitions.push([fromId, sym, toId]);
+      }
+    }
+  }
+
+  const finalId = id();
+  A.states.set(finalId, { id: finalId, name: 'F', x: 120 + Math.random()*320, y: 120 + Math.random()*220, isInitial: false, isFinal: true });
+
+  for (const [src, sym, dest] of transitions) {
+    const to = dest === 'FINAL' ? finalId : dest;
+    const k = keyTS(src, sym);
+    if (!A.transitions.has(k)) A.transitions.set(k, new Set());
+    A.transitions.get(k).add(to);
+  }
+
+  A.alphabet = alphabet;
+  elAlphabetView.textContent = `Σ = { ${alphaStr()} }`;
+
+  if (startNt) {
+    const initId = ntMap.get(startNt);
+    A.states.get(initId).isInitial = true;
+    A.initialId = initId;
+  }
+
+  renderAll();
+  saveLS();
+}
+
+document.getElementById('buildFromGrammarBtn').onclick = buildFromGrammar;


### PR DESCRIPTION
## Summary
- add `gr.html` page to build automata from regular grammars
- expose grammar conversion logic in new `js/grammar.js`
- update navigation links and README

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_68b4c070e2e48333b6ebab1a094b020c