### PR TITLE
Add stepper for DFA→regex conversion

### DIFF
--- a/js/algoview.js
+++ b/js/algoview.js
@@ -2,6 +2,7 @@ const elSteps = document.getElementById('algoSteps');
 const titles = {
   removeLambda: 'AFNλ → AFN',
   nfaToDfa: 'AFN → AFD',
+  dfaToRegex: 'AFD → ER',
 };
 
 function nameOf(id) {
@@ -41,6 +42,26 @@ document.addEventListener('algoStep', ev => {
       runHighlight.set(data.from, 'running');
       runHighlight.set(data.to, 'running');
       renderStates();
+    } else {
+      div.textContent = `${step}`;
+    }
+  } else if (algo === 'dfaToRegex') {
+    if (step === 'eliminate') {
+      div.textContent = `eliminando ${nameOf(data.state)}`;
+      runHighlight.clear();
+      runHighlight.set(data.state, 'running');
+      renderStates();
+    } else if (step === 'transition') {
+      div.textContent = `${data.fromName} → ${data.toName} via ${nameOf(data.via)}: ${data.regex}`;
+      runHighlight.clear();
+      if (data.from) runHighlight.set(data.from, 'running');
+      if (data.via) runHighlight.set(data.via, 'running');
+      if (data.to) runHighlight.set(data.to, 'running');
+      renderStates();
+    } else if (step === 'remove') {
+      div.textContent = `estado ${nameOf(data.state)} removido`;
+    } else if (step === 'final') {
+      div.textContent = `ER = ${data.regex}`;
     } else {
       div.textContent = `${step}`;
     }


### PR DESCRIPTION
## Summary
- Track DFA→regex conversion steps, highlighting each state removal and transition update
- Simplify union operation for more compact regular expressions
- Display DFA→regex steps in algorithm visualization panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba386a24648333b12024ad15467c54