### PR TITLE
fix: guard NFA clone

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -737,8 +737,10 @@
           const arr = Array.isArray(v) ? v : [v];
           const key = keyTS(map.get(src), sym);
           const set = transitions.get(key) || new Set();
-          arr.forEach(d => set.add(map.get(d)));
-          transitions.set(key, set);
+          arr.forEach(d => {
+            if (map.has(d)) set.add(map.get(d));
+          });
+          if (set.size) transitions.set(key, set);
         }
       }
 


### PR DESCRIPTION
## Summary
- avoid inserting undefined destination states when cloning NFAs

## Testing
- `node --check js/core.js`


------
https://chatgpt.com/codex/tasks/task_e_68bde8d91c24833388f1aa2e6dca5841