### PR TITLE
Modularize frontend scripts around shared core

### DIFF
--- a/afn.html
+++ b/afn.html
@@ -125,9 +125,8 @@
   </div>
 
     <script>window.LS_KEY='afn_sim_state_v1';</script>
-    <script src="js/core.js"></script>
-    <script src="js/run.js"></script>
-    <script src="js/algoview.js"></script>
+    <script type="module" src="js/run.js"></script>
+    <script type="module" src="js/algoview.js"></script>
   </body>
 
 </html>

--- a/gr.html
+++ b/gr.html
@@ -143,11 +143,10 @@
   </div>
 
     <script>window.LS_KEY='afn_gr_sim_state_v1';</script>
-    <script src="js/core.js"></script>
-    <script src="js/regex.js"></script>
-    <script src="js/grammar.js"></script>
-    <script src="js/run.js"></script>
-    <script src="js/algoview.js"></script>
+    <script type="module" src="js/regex.js"></script>
+    <script type="module" src="js/grammar.js"></script>
+    <script type="module" src="js/run.js"></script>
+    <script type="module" src="js/algoview.js"></script>
   </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -115,8 +115,7 @@
     </div>
   </div>
 
-    <script src="js/core.js"></script>
-    <script src="js/run.js"></script>
+    <script type="module" src="js/run.js"></script>
   </body>
 
 </html>

--- a/js/algoview.js
+++ b/js/algoview.js
@@ -1,3 +1,5 @@
+import { A, runHighlight, renderStates } from './core.js';
+
 const elSteps = document.getElementById('algoSteps');
 const titles = {
   removeLambda: 'AFNλ → AFN',

--- a/js/core.js
+++ b/js/core.js
@@ -1,5 +1,5 @@
     /* -------------------- Modelo de dados -------------------- */
-    const A = {
+export const A = {
       alphabet: new Set(),
       states: new Map(),            // id -> {id,name,x,y,isInitial,isFinal}
       nextId: 0,
@@ -13,17 +13,17 @@
     const LS_KEY = window.LS_KEY || 'afd_sim_state_v3';
     const IS_AFN = LS_KEY.startsWith('afn');
 
-    const svg = document.getElementById('svg');
+export const svg = document.getElementById('svg');
     const gStates = document.getElementById('states');
     const gEdges = document.getElementById('edges');
     const gLabels = document.getElementById('labels');
     const gInitial = document.getElementById('initialPointers');
 
-    const elAlphabetView = document.getElementById('alphabetView');
+export const elAlphabetView = document.getElementById('alphabetView');
     const elTransitionsList = document.getElementById('transitionsList');
     const elRegexOut = document.getElementById('regexOut');
     const elRegexMsg = document.getElementById('regexMsg');
-    let runHighlight = new Map();
+export let runHighlight = new Map();
     document.getElementById('unionBtn').onclick = () => importTwoNFAs('union');
     document.getElementById('concatBtn').onclick = () => importTwoNFAs('concat');
     document.getElementById('closureBtn').onclick = () => importOneNFAStar();
@@ -31,11 +31,11 @@
 
 
     /* -------------------- Utilidades -------------------- */
-    const keyTS = (s, sym) => `${s}|${sym}`;
-    const id = () => `q${A.nextId++}`;
+export const keyTS = (s, sym) => `${s}|${sym}`;
+export const id = () => `q${A.nextId++}`;
     const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
 
-    function alphaStr() {
+export function alphaStr() {
       return Array.from(A.alphabet).join(', ');
     }
     function markSelected(id) {
@@ -77,7 +77,7 @@
         initialId: A.initialId,
       };
     }
-    function saveLS() {
+export function saveLS() {
       try { localStorage.setItem(LS_KEY, JSON.stringify(snapshot())); } catch (e) { console.warn('localStorage save failed', e); }
     }
     function loadLS() {
@@ -89,7 +89,7 @@
         return true;
       } catch (e) { console.warn('localStorage load failed', e); return false; }
     }
-    function resetAll() {
+export function resetAll() {
       localStorage.removeItem(LS_KEY);
       A.alphabet = new Set();
       A.states.clear();
@@ -232,7 +232,7 @@
     }
 
     /* -------------------- Canvas: estados (arrastar) -------------------- */
-    function renderStates() {
+export function renderStates() {
       gStates.innerHTML = '';
       gInitial.innerHTML = '';
       for (const s of A.states.values()) {
@@ -480,7 +480,7 @@
     }
 
     /* -------------------- Render geral -------------------- */
-    function renderAll() {
+export function renderAll() {
       renderStates();
       renderEdges();
     }

--- a/js/grammar.js
+++ b/js/grammar.js
@@ -1,3 +1,5 @@
+import { resetAll, id, A, keyTS, alphaStr, renderAll, saveLS, elAlphabetView } from './core.js';
+
 // Constrói um AF a partir de uma gramática regular
 function buildFromGrammar() {
   const raw = document.getElementById('grammarInput').value;

--- a/js/regex.js
+++ b/js/regex.js
@@ -1,3 +1,5 @@
+import { resetAll, A, alphaStr, renderAll, saveLS, id, keyTS, elAlphabetView } from './core.js';
+
 // Constrói um AFNλ a partir de uma expressão regular usando a construção de Thompson
 function buildFromRegex() {
   const raw = (document.getElementById('regexInput').value || '').trim();

--- a/js/run.js
+++ b/js/run.js
@@ -1,3 +1,5 @@
+import { A, keyTS, alphaStr, runHighlight, renderStates, svg } from './core.js';
+
 const elRunResult = document.getElementById('runResult');
 const elRunSteps = document.getElementById('runSteps');
 const runBtn = document.getElementById('runBtn');


### PR DESCRIPTION
## Summary
- export automaton state and helpers from new core module
- convert feature scripts to ES modules importing shared logic
- load modules via `type="module"` scripts in HTML pages

## Testing
- `node --check js/core.js`
- `node --check js/run.js`
- `node --check js/algoview.js`
- `node --check js/regex.js`
- `node --check js/grammar.js`


------
https://chatgpt.com/codex/tasks/task_e_68c569bf2fd083338dd4fa7b841ec7d7