### PR TITLE
Add PNG export and example automata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+instructions.md
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ just a automaton simulator to practice Foundations of Theoretical Computer Scien
 - Build and edit deterministic and nondeterministic finite automata (with λ-transitions) in the browser.
 - Generate finite automata from regular grammars on the new `gr.html` page.
 - Simulate words normally via **Rodar** or step-by-step using **Modo Run** with a manual *Passo* button.
+- Export the current canvas as a PNG image.
+- Load classic automata from the **Exemplos** menu for quick experiments.
 
 ## Algorithm visualization
 

--- a/afn.html
+++ b/afn.html
@@ -75,7 +75,14 @@
       <div class="toolbar">
         <button id="exportBtn" class="btn-soft">Exportar AF</button>
         <button id="importBtn" class="btn-soft">Importar AF</button>
+        <button id="exportPngBtn" class="btn-soft">Exportar PNG</button>
         <input type="file" id="importFile" accept="application/json" style="display:none" />
+      </div>
+      <div class="row" style="margin-top:6px;">
+        <select id="examplesSelect">
+          <option value="">Carregar exemplo...</option>
+        </select>
+        <button id="loadExampleBtn" class="btn-soft">Carregar</button>
       </div>
       <div class="mini muted">Exporta um JSON com Σ, estados, transições, inicial e <code>nextId</code>. Importar
         substituirá o AF atual.</div>

--- a/examples/afd_binary_divisible_by_3.json
+++ b/examples/afd_binary_divisible_by_3.json
@@ -1,0 +1,19 @@
+{
+  "version": 3,
+  "alphabet": ["0", "1"],
+  "states": [
+    {"id": "q0", "name": "q0", "x": 200, "y": 200, "isInitial": true, "isFinal": true},
+    {"id": "q1", "name": "q1", "x": 380, "y": 200, "isInitial": false, "isFinal": false},
+    {"id": "q2", "name": "q2", "x": 560, "y": 200, "isInitial": false, "isFinal": false}
+  ],
+  "nextId": 3,
+  "transitions": [
+    ["q0|0", ["q0"]],
+    ["q0|1", ["q1"]],
+    ["q1|0", ["q2"]],
+    ["q1|1", ["q0"]],
+    ["q2|0", ["q1"]],
+    ["q2|1", ["q2"]]
+  ],
+  "initialId": "q0"
+}

--- a/examples/afd_ends_with_a.json
+++ b/examples/afd_ends_with_a.json
@@ -1,0 +1,16 @@
+{
+  "version": 3,
+  "alphabet": ["a", "b"],
+  "states": [
+    {"id": "q0", "name": "q0", "x": 200, "y": 220, "isInitial": true, "isFinal": false},
+    {"id": "q1", "name": "q1", "x": 380, "y": 220, "isInitial": false, "isFinal": true}
+  ],
+  "nextId": 2,
+  "transitions": [
+    ["q0|a", ["q1"]],
+    ["q0|b", ["q0"]],
+    ["q1|a", ["q1"]],
+    ["q1|b", ["q0"]]
+  ],
+  "initialId": "q0"
+}

--- a/examples/afd_parity_AB.json
+++ b/examples/afd_parity_AB.json
@@ -1,0 +1,14 @@
+{
+  "version": 3,
+  "alphabet": ["A", "B"],
+  "states": [
+    {"id": "q0", "name": "q0", "x": 180, "y": 200, "isInitial": true, "isFinal": false},
+    {"id": "q1", "name": "q1", "x": 360, "y": 200, "isInitial": false, "isFinal": true}
+  ],
+  "nextId": 2,
+  "transitions": [
+    ["q0|A", ["q1"]],
+    ["q1|B", ["q0"]]
+  ],
+  "initialId": "q0"
+}

--- a/examples/afn_lambda_a_or_ab.json
+++ b/examples/afn_lambda_a_or_ab.json
@@ -1,0 +1,16 @@
+{
+  "version": 3,
+  "alphabet": ["a", "b", "λ"],
+  "states": [
+    {"id": "s0", "name": "s0", "x": 160, "y": 200, "isInitial": true, "isFinal": false},
+    {"id": "s1", "name": "s1", "x": 320, "y": 200, "isInitial": false, "isFinal": false},
+    {"id": "s2", "name": "s2", "x": 500, "y": 200, "isInitial": false, "isFinal": true}
+  ],
+  "nextId": 3,
+  "transitions": [
+    ["s0|a", ["s1"]],
+    ["s1|b", ["s2"]],
+    ["s1|λ", ["s2"]]
+  ],
+  "initialId": "s0"
+}

--- a/gr.html
+++ b/gr.html
@@ -93,7 +93,14 @@
       <div class="toolbar">
         <button id="exportBtn" class="btn-soft">Exportar AF</button>
         <button id="importBtn" class="btn-soft">Importar AF</button>
+        <button id="exportPngBtn" class="btn-soft">Exportar PNG</button>
         <input type="file" id="importFile" accept="application/json" style="display:none" />
+      </div>
+      <div class="row" style="margin-top:6px;">
+        <select id="examplesSelect">
+          <option value="">Carregar exemplo...</option>
+        </select>
+        <button id="loadExampleBtn" class="btn-soft">Carregar</button>
       </div>
       <div class="mini muted">Exporta um JSON com Σ, estados, transições, inicial e <code>nextId</code>. Importar
         substituirá o AF atual.</div>

--- a/index.html
+++ b/index.html
@@ -75,7 +75,14 @@
       <div class="toolbar">
         <button id="exportBtn" class="btn-soft">Exportar AF</button>
         <button id="importBtn" class="btn-soft">Importar AF</button>
+        <button id="exportPngBtn" class="btn-soft">Exportar PNG</button>
         <input type="file" id="importFile" accept="application/json" style="display:none" />
+      </div>
+      <div class="row" style="margin-top:6px;">
+        <select id="examplesSelect">
+          <option value="">Carregar exemplo...</option>
+        </select>
+        <button id="loadExampleBtn" class="btn-soft">Carregar</button>
       </div>
       <div class="mini muted">Exporta um JSON com Σ, estados, transições, inicial e <code>nextId</code>. Importar
         substituirá o AF atual.</div>

--- a/js/core.js
+++ b/js/core.js
@@ -203,6 +203,58 @@ export function resetAll() {
       reader.readAsText(file);
     };
 
+    const exportPngBtn = document.getElementById('exportPngBtn');
+    if (exportPngBtn) {
+      exportPngBtn.onclick = () => {
+        const xml = new XMLSerializer().serializeToString(svg);
+        const svgBlob = new Blob([xml], { type: 'image/svg+xml;charset=utf-8' });
+        const url = URL.createObjectURL(svgBlob);
+        const img = new Image();
+        img.onload = () => {
+          const canvas = document.createElement('canvas');
+          canvas.width = svg.clientWidth;
+          canvas.height = svg.clientHeight;
+          const ctx = canvas.getContext('2d');
+          ctx.fillStyle = '#ffffff';
+          ctx.fillRect(0, 0, canvas.width, canvas.height);
+          ctx.drawImage(img, 0, 0);
+          URL.revokeObjectURL(url);
+          const a = document.createElement('a');
+          a.href = canvas.toDataURL('image/png');
+          a.download = 'automato.png';
+          document.body.appendChild(a); a.click(); a.remove();
+        };
+        img.src = url;
+      };
+    }
+
+    const examplesSelect = document.getElementById('examplesSelect');
+    const loadExampleBtn = document.getElementById('loadExampleBtn');
+    if (examplesSelect && loadExampleBtn) {
+      const examples = IS_AFN ? {
+        'λ-automato a ou ab': 'examples/afn_lambda_a_or_ab.json'
+      } : {
+        'Binário divisível por 3': 'examples/afd_binary_divisible_by_3.json',
+        'Termina com a': 'examples/afd_ends_with_a.json',
+        'Paridade A/B': 'examples/afd_parity_AB.json'
+      };
+      for (const [label, path] of Object.entries(examples)) {
+        const opt = document.createElement('option');
+        opt.value = path;
+        opt.textContent = label;
+        examplesSelect.appendChild(opt);
+      }
+      loadExampleBtn.onclick = async () => {
+        const path = examplesSelect.value;
+        if (!path) return;
+        const obj = await fetch(path).then(r => r.json());
+        if (!confirm('Importar irá substituir o AFD atual. Continuar?')) return;
+        restoreFromObject(obj);
+        saveLS();
+        renderAll();
+      };
+    }
+
     function restoreFromObject(obj) {
       // validações básicas
       if (!obj || typeof obj !== 'object') throw new Error('JSON malformado');


### PR DESCRIPTION
## Summary
- allow exporting the current automaton canvas as a PNG image
- add examples menu with several predefined automata
- document new functionality and include example JSON files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bc695e1c8333abd959fb67c27309